### PR TITLE
fix: swagger url serveur

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,3 +17,6 @@ SMTP_FROM=test@test.com
 MES_ADRESSES_URL=http://localhost:3000
 MES_ADRESSES_API_URL=http://localhost:5001
 MES_ADRESSES_API_TOKEN=
+
+# SWAGGER
+API_SIGNALEMENT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-signalement

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Elles peuvent être définies classiquement ou en créant un fichier `.env` sur 
 | `SMTP_URL`                  | URL de connexion au serveur SMTP |
 | `SMTP_FROM`                 | Expéditeur SMTP                  |
 | `PORT`                      | Port de l'api                    |
+| `API_SIGNALEMENT_URL`       | Url de l'api                     |
 
 ## Licence
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function bootstrap() {
     .setTitle('API Signalement')
     .setDescription("API permettant de signaler des problèmes d'adressage")
     .setVersion('1.0')
+    .addServer(process.env.API_SIGNALEMENT_URL)
     .addBearerAuth(
       {
         description: `Please enter a valid source token`,


### PR DESCRIPTION
## CONTEXT

- Actuellement le swagger sur la prod ne marche pas car la requète du swagger ne comprend pas le sous domain /api-signalement

## CHANGEMENT

- Ajout de la variable d'env `API_SIGNALEMENT_URL`
- Fixer l'url de requétage du swagger sur  `API_SIGNALEMENT_URL`