### PR TITLE
fix: numero string in changes requested

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,11 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('API Signalement')

--- a/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
+++ b/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
@@ -28,16 +28,14 @@ export class FixNumeroStringInChangesRequested1753283848477
         .map(({ id, changesRequested }: { id: string; changesRequested }) => {
           const { numero } = changesRequested as NumeroChangesRequestedDTO;
 
-          if (numero && typeof numero === 'string') {
-            console.log(
-              `Signalement ${id} has a string numero, converting to number : ${numero}`,
-            );
+          console.log(
+            `Signalement ${id} has a string numero, converting to number : ${numero}`,
+          );
 
-            return queryRunner.query(
-              `UPDATE "signalements" SET "changes_requested" = jsonb_set("changes_requested", '{numero}', $1) WHERE id = $2`,
-              [parseInt(numero, 10), id],
-            );
-          }
+          return queryRunner.query(
+            `UPDATE "signalements" SET "changes_requested" = jsonb_set("changes_requested", '{numero}', $1) WHERE id = $2`,
+            [parseInt(numero as unknown as string, 10), id],
+          );
         }),
     );
   }

--- a/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
+++ b/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
@@ -26,7 +26,8 @@ export class FixNumeroStringInChangesRequested1753283848477
           );
 
           return queryRunner.query(
-            `UPDATE "signalements" SET "changes_requested" = jsonb_set("changes_requested", '{numero}', '${parseInt(numero, 10)}') WHERE id = '${id}'`,
+            `UPDATE "signalements" SET "changes_requested" = jsonb_set("changes_requested", '{numero}', $1) WHERE id = $2`,
+            [parseInt(numero, 10), id],
           );
         }
       }),

--- a/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
+++ b/src/migrations/1753283848477-fix-numero-string-in-changes-requested.ts
@@ -17,8 +17,8 @@ export class FixNumeroStringInChangesRequested1753283848477
 
     // Update all signalements with their point
     await Promise.all(
-      signalements.map(({ id, changesRequested }) => {
-        const { numero } = changesRequested as any;
+      signalements.map(({ id, changesRequested }: { id: string; changesRequested: ChangesRequested }) => {
+        const { numero } = changesRequested;
 
         if (numero && typeof numero === 'string') {
           console.log(

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -2,10 +2,12 @@ import { PostGisAddSignalementPoint1741898533813 } from './1741898533813-postgis
 import { AddRejectionReason1746196994065 } from './1746196994065-add-rejection-reason';
 import { AddSettings1747315664342 } from './1747315664342-add-settings';
 import { COG2025_1750325214122 } from './1750325214122-cog-2025';
+import { FixNumeroStringInChangesRequested1753283848477 } from './1753283848477-fix-numero-string-in-changes-requested';
 
 export const migrations = [
   PostGisAddSignalementPoint1741898533813,
   AddRejectionReason1746196994065,
   AddSettings1747315664342,
   COG2025_1750325214122,
+  FixNumeroStringInChangesRequested1753283848477,
 ];

--- a/src/modules/signalement/dto/changes-requested.dto.ts
+++ b/src/modules/signalement/dto/changes-requested.dto.ts
@@ -1,15 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsOptional,
   IsArray,
   ArrayNotEmpty,
   ValidateNested,
+  IsNumber,
 } from 'class-validator';
 import { PositionDTO } from './position.dto';
 
 export class NumeroChangesRequestedDTO {
   @ApiProperty({ required: true, nullable: false, type: Number })
+  @IsNumber()
+  @Transform(({ value }) => Number(value))
   numero: number;
 
   @ApiProperty({ required: false, nullable: false, type: String })

--- a/src/tests/client.spec.ts
+++ b/src/tests/client.spec.ts
@@ -48,7 +48,11 @@ describe('Client module', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
     await app.init();
   });
 

--- a/src/tests/signalement.spec.ts
+++ b/src/tests/signalement.spec.ts
@@ -1239,6 +1239,83 @@ describe('Signalement module', () => {
       });
     });
 
+    it("should cast the numero to type number with pipe if it's a string", async () => {
+      const { token, ...privateSource } = await createRecording(
+        sourceRepository,
+        new Source({
+          nom: 'Pifomètre',
+          type: SourceTypeEnum.PRIVATE,
+        }),
+      );
+
+      const createSignalementDTO: CreateSignalementDTO = {
+        codeCommune: '37001',
+        type: SignalementTypeEnum.LOCATION_TO_UPDATE,
+        existingLocation: {
+          type: ExistingLocationTypeEnum.NUMERO,
+          numero: 2,
+          suffixe: 'bis',
+          position: {
+            type: PositionTypeEnum.BATIMENT,
+            point: {
+              type: 'Point',
+              coordinates: [0.982904, 47.410998],
+            },
+          },
+          toponyme: {
+            type: ExistingLocationTypeEnum.VOIE,
+            nom: 'Rue de la Paix',
+          },
+        } as ExistingNumero,
+        changesRequested: {
+          numero: '3' as unknown as number,
+          suffixe: 'ter',
+          positions: [
+            {
+              type: PositionTypeEnum.BATIMENT,
+              point: {
+                type: 'Point',
+                coordinates: [0.982904, 47.410998],
+              },
+            },
+          ],
+          parcelles: ['37003000BA0744', '37003000BA0743'],
+          nomVoie: 'Rue de la Paix',
+        } as NumeroChangesRequestedDTO,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post(`/signalements?sourceId=${privateSource.id}`)
+        .send(createSignalementDTO)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body).toEqual({
+        ...createSignalementDTO,
+        changesRequested: {
+          ...createSignalementDTO.changesRequested,
+          numero: 3,
+        },
+        id: expect.any(String),
+        nomCommune: getCommune(createSignalementDTO.codeCommune)?.nom,
+        point: {
+          coordinates: expect.any(Array),
+          type: 'Point',
+        },
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+        deletedAt: null,
+        processedBy: null,
+        rejectionReason: null,
+        source: {
+          ...privateSource,
+          createdAt: expect.any(String),
+          updatedAt: expect.any(String),
+        },
+        status: SignalementStatusEnum.PENDING,
+      });
+    });
+
     it('should create a signalement of type LOCATION_TO_DELETE', async () => {
       const { token, ...privateSource } = await createRecording(
         sourceRepository,

--- a/src/tests/signalement.spec.ts
+++ b/src/tests/signalement.spec.ts
@@ -159,7 +159,11 @@ describe('Signalement module', () => {
       .compile();
 
     app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
     await app.init();
 
     // INIT MODEL

--- a/src/tests/source.spec.ts
+++ b/src/tests/source.spec.ts
@@ -54,7 +54,11 @@ describe('Source module', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe());
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+      }),
+    );
     await app.init();
     sourceRepository = app.get(getRepositoryToken(Source));
   });


### PR DESCRIPTION
Parfois quand un numéro d'adresse est stocké sous forme de string, on récupère des erreurs 400 sur mes-adresses à la validation du signalement.
Cette PR s'assure que tous les numéros sont des numbers